### PR TITLE
docs: update README example email and remove license block

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ uid: bborbe
 cn: Benjamin Borbe
 givenName: Benjamin
 sn: Borbe
-mail: bborbe@rocketnews.de
+mail: benjamin.borbe@gmail.com
 ```
 
 ldapadd -x -W -D "cn=root,dc=example,dc=com" -f user.ldif
@@ -88,31 +88,3 @@ member: uid=bborbe,ou=users,dc=example,dc=com
 
 ldapadd -x -W -D "cn=root,dc=example,dc=com" -f group-admins.ldif
 
-
-## Copyright and license
-
-    Copyright (c) 2016, Benjamin Borbe <bborbe@rocketnews.de>
-    All rights reserved.
-    
-    Redistribution and use in source and binary forms, with or without
-    modification, are permitted provided that the following conditions are
-    met:
-    
-       * Redistributions of source code must retain the above copyright
-         notice, this list of conditions and the following disclaimer.
-       * Redistributions in binary form must reproduce the above
-         copyright notice, this list of conditions and the following
-         disclaimer in the documentation and/or other materials provided
-         with the distribution.
-
-    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
-    "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
-    LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
-    A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
-    OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
-    SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
-    LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
-    DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
-    THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-    (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-    OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.


### PR DESCRIPTION
## Summary
- update README user example email to 
- remove inline copyright/license section from README

## Why
Keep examples current and avoid duplicating license text in README.